### PR TITLE
feat: 내정보 조회 api 구현

### DIFF
--- a/api-server/build.gradle.kts
+++ b/api-server/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
 
     // tests
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("com.ninja-squad:springmockk:4.0.2")

--- a/api-server/src/main/kotlin/com/imagesprint/apiserver/controller/auth/AuthController.kt
+++ b/api-server/src/main/kotlin/com/imagesprint/apiserver/controller/auth/AuthController.kt
@@ -5,7 +5,7 @@ import com.imagesprint.apiserver.controller.auth.dto.SocialLoginResponse
 import com.imagesprint.apiserver.controller.common.ApiResultResponse
 import com.imagesprint.apiserver.controller.common.ApiVersions
 import com.imagesprint.apiserver.controller.common.BaseController
-import com.imagesprint.core.port.`in`.user.SocialLoginUseCase
+import com.imagesprint.core.port.input.user.SocialLoginUseCase
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
 import org.springframework.http.ResponseCookie
@@ -17,21 +17,25 @@ import java.time.Duration
 
 @RestController
 @RequestMapping("${ApiVersions.V1}/auth")
-class AuthController(private val socialLoginUseCase: SocialLoginUseCase) : BaseController() {
-
+class AuthController(
+    private val socialLoginUseCase: SocialLoginUseCase,
+) : BaseController() {
     @PostMapping("/login")
-    fun login(
+    fun loginWithSocial(
         @RequestBody @Valid request: SocialLoginRequest,
-        response: HttpServletResponse
+        response: HttpServletResponse,
     ): ApiResultResponse<SocialLoginResponse> {
-        val result = socialLoginUseCase.socialAuthenticate(request.toCommand())
+        val result = socialLoginUseCase.loginWithSocial(request.toCommand())
 
-        val refreshTokenCookie = ResponseCookie.from("refreshToken", result.refreshToken)
-            .httpOnly(true)
-            .secure(true)
-            .path("/")
-            .maxAge(Duration.ofDays(30))
-            .build()
+        val refreshTokenCookie =
+            ResponseCookie
+                .from("refreshToken", result.refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path("/")
+                .maxAge(Duration.ofDays(30))
+                .build()
 
         response.addHeader("Set-Cookie", refreshTokenCookie.toString())
 

--- a/api-server/src/main/kotlin/com/imagesprint/apiserver/controller/auth/dto/SocialLoginRequest.kt
+++ b/api-server/src/main/kotlin/com/imagesprint/apiserver/controller/auth/dto/SocialLoginRequest.kt
@@ -1,7 +1,7 @@
 package com.imagesprint.apiserver.controller.auth.dto
 
 import com.imagesprint.core.domain.user.SocialProvider
-import com.imagesprint.core.port.`in`.user.SocialAuthCommand
+import com.imagesprint.core.port.input.user.SocialAuthCommand
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 
@@ -10,13 +10,12 @@ data class SocialLoginRequest(
     val authorizationCode: String,
     @field:NotNull(message = "provider는 필수입니다.")
     val provider: SocialProvider,
-    val state: String?
+    val state: String?,
 ) {
-    fun toCommand(): SocialAuthCommand {
-        return SocialAuthCommand(
+    fun toCommand(): SocialAuthCommand =
+        SocialAuthCommand(
             authorizationCode = this.authorizationCode,
             provider = this.provider,
-            state = this.state
+            state = this.state,
         )
-    }
 }

--- a/api-server/src/main/kotlin/com/imagesprint/apiserver/controller/user/UserController.kt
+++ b/api-server/src/main/kotlin/com/imagesprint/apiserver/controller/user/UserController.kt
@@ -1,0 +1,27 @@
+package com.imagesprint.apiserver.controller.user
+
+import com.imagesprint.apiserver.controller.common.ApiResultResponse
+import com.imagesprint.apiserver.controller.common.ApiResultResponse.Companion.ok
+import com.imagesprint.apiserver.controller.common.ApiVersions
+import com.imagesprint.apiserver.controller.user.dto.MyProfileResponse
+import com.imagesprint.apiserver.security.AuthenticatedUser
+import com.imagesprint.core.port.input.user.UserQueryUseCase
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("${ApiVersions.V1}/users")
+class UserController(
+    private val userQueryUseCase: UserQueryUseCase,
+) {
+    @GetMapping("/me")
+    fun getMyProfile(
+        @AuthenticationPrincipal authenticatedUser: AuthenticatedUser,
+    ): ApiResultResponse<MyProfileResponse> {
+        val result = userQueryUseCase.getMyProfile(authenticatedUser.userId)
+
+        return ok(MyProfileResponse.from(result))
+    }
+}

--- a/api-server/src/main/kotlin/com/imagesprint/apiserver/controller/user/dto/MyProfileResponse.kt
+++ b/api-server/src/main/kotlin/com/imagesprint/apiserver/controller/user/dto/MyProfileResponse.kt
@@ -1,0 +1,24 @@
+package com.imagesprint.apiserver.controller.user.dto
+
+import com.imagesprint.core.domain.user.SocialProvider
+import com.imagesprint.core.port.input.user.MyProfileResult
+import java.time.LocalDateTime
+
+data class MyProfileResponse(
+    val userId: Long,
+    val nickname: String,
+    val email: String,
+    val provider: SocialProvider,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(result: MyProfileResult): MyProfileResponse =
+            MyProfileResponse(
+                result.userId,
+                result.nickname,
+                result.email,
+                result.provider,
+                result.createdAt,
+            )
+    }
+}

--- a/api-server/src/main/kotlin/com/imagesprint/apiserver/security/JwtAuthenticationFilter.kt
+++ b/api-server/src/main/kotlin/com/imagesprint/apiserver/security/JwtAuthenticationFilter.kt
@@ -1,6 +1,6 @@
 package com.imagesprint.apiserver.security
 
-import com.imagesprint.core.port.out.token.TokenProvider
+import com.imagesprint.core.port.output.token.TokenProvider
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -11,13 +11,12 @@ import org.springframework.web.filter.OncePerRequestFilter
 
 @Component
 class JwtAuthenticationFilter(
-    private val tokenProvider: TokenProvider
+    private val tokenProvider: TokenProvider,
 ) : OncePerRequestFilter() {
-
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
-        filterChain: FilterChain
+        filterChain: FilterChain,
     ) {
         val token = extractToken(request)
 
@@ -25,11 +24,12 @@ class JwtAuthenticationFilter(
             val userId = tokenProvider.getUserIdFromToken(token)
             val provider = tokenProvider.getProviderFromToken(token)
 
-            val authentication = UsernamePasswordAuthenticationToken(
-                AuthenticatedUser(userId, provider),
-                null,
-                emptyList()
-            )
+            val authentication =
+                UsernamePasswordAuthenticationToken(
+                    AuthenticatedUser(userId, provider),
+                    null,
+                    emptyList(),
+                )
             SecurityContextHolder.getContext().authentication = authentication
         }
 

--- a/api-server/src/test/kotlin/com/imagesprint/apiserver/controller/auth/AuthIntegrationTest.kt
+++ b/api-server/src/test/kotlin/com/imagesprint/apiserver/controller/auth/AuthIntegrationTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("ktlint:standard:no-wildcard-imports")
-
 package com.imagesprint.apiserver.controller.auth
 
 import com.imagesprint.apiserver.support.SocialAuthMockConfig
@@ -10,7 +8,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
-import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
@@ -18,8 +16,8 @@ import kotlin.test.Test
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@TestPropertySource(locations = ["classpath:application-test.yml"])
 @Import(SocialAuthMockConfig::class)
+@ActiveProfiles("test")
 class AuthIntegrationTest {
     @Autowired
     private lateinit var mockMvc: MockMvc

--- a/api-server/src/test/kotlin/com/imagesprint/apiserver/controller/auth/AuthIntegrationTest.kt
+++ b/api-server/src/test/kotlin/com/imagesprint/apiserver/controller/auth/AuthIntegrationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
 package com.imagesprint.apiserver.controller.auth
 
 import com.imagesprint.apiserver.support.SocialAuthMockConfig
@@ -19,7 +21,6 @@ import kotlin.test.Test
 @TestPropertySource(locations = ["classpath:application-test.yml"])
 @Import(SocialAuthMockConfig::class)
 class AuthIntegrationTest {
-
     @Autowired
     private lateinit var mockMvc: MockMvc
 
@@ -33,20 +34,23 @@ class AuthIntegrationTest {
 
     @Test
     fun `로그인 요청 시 accessToken과 쿠키가 반환된다`() {
-        mockMvc.perform(
-            post("/api/v1/auth/login")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(
-                    """
-                    {
-                        "authorizationCode": "fake-code",
-                        "provider": "KAKAO",
-                        "state": "test"
-                    }
-                    """.trimIndent()
-                )
-        )
-            .andExpect(status().isOk)
+        // given
+        val requestBody =
+            """
+            {
+                "authorizationCode": "fake-code",
+                "provider": "KAKAO",
+                "state": "test"
+            }
+            """.trimIndent()
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody),
+            ).andExpect(status().isOk)
             .andExpect(jsonPath("$.data.accessToken").isNotEmpty)
             .andExpect(header().exists("Set-Cookie"))
     }

--- a/api-server/src/test/kotlin/com/imagesprint/apiserver/controller/user/UserControllerTest.kt
+++ b/api-server/src/test/kotlin/com/imagesprint/apiserver/controller/user/UserControllerTest.kt
@@ -1,0 +1,58 @@
+package com.imagesprint.apiserver.controller.user
+
+import com.imagesprint.apiserver.support.WithMockAuthenticatedUser
+import com.imagesprint.core.domain.user.SocialProvider
+import com.imagesprint.core.port.input.user.MyProfileResult
+import com.imagesprint.core.port.input.user.UserQueryUseCase
+import com.imagesprint.core.port.output.token.TokenProvider
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDateTime
+import kotlin.test.Test
+
+@WebMvcTest(UserController::class)
+@AutoConfigureMockMvc(addFilters = false)
+class UserControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockkBean
+    private lateinit var userQueryUseCase: UserQueryUseCase
+
+    @MockkBean
+    private lateinit var tokenProvider: TokenProvider
+
+    @Test
+    @WithMockAuthenticatedUser(userId = 123, provider = "KAKAO")
+    fun `유저 정보 조회 시 200 OK와 유저 정보를 반환한다`() {
+        // given
+        every { userQueryUseCase.getMyProfile(any()) } returns
+            MyProfileResult(
+                1L,
+                "test",
+                "test@test.com",
+                SocialProvider.KAKAO,
+                LocalDateTime.now(),
+            )
+
+        // when & then
+        mockMvc
+            .perform(
+                get("/api/v1/users/me")
+                    .contentType(MediaType.APPLICATION_JSON),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.userId").value(1L))
+            .andExpect(jsonPath("$.data.nickname").value("test"))
+            .andExpect(jsonPath("$.data.email").value("test@test.com"))
+            .andDo(print())
+    }
+}

--- a/api-server/src/test/kotlin/com/imagesprint/apiserver/controller/user/UserIntegrationTest.kt
+++ b/api-server/src/test/kotlin/com/imagesprint/apiserver/controller/user/UserIntegrationTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("ktlint:standard:no-wildcard-imports")
-
 package com.imagesprint.apiserver.controller.user
 
 import com.imagesprint.apiserver.support.WithMockAuthenticatedUser
@@ -12,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -21,6 +20,7 @@ import kotlin.test.Test
 @SpringBootTest
 @AutoConfigureMockMvc
 @TestPropertySource(locations = ["classpath:application-test.yml"])
+@ActiveProfiles("test")
 class UserIntegrationTest {
     @Autowired
     private lateinit var mockMvc: MockMvc

--- a/api-server/src/test/kotlin/com/imagesprint/apiserver/controller/user/UserIntegrationTest.kt
+++ b/api-server/src/test/kotlin/com/imagesprint/apiserver/controller/user/UserIntegrationTest.kt
@@ -1,0 +1,77 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package com.imagesprint.apiserver.controller.user
+
+import com.imagesprint.apiserver.support.WithMockAuthenticatedUser
+import com.imagesprint.core.domain.user.SocialProvider
+import com.imagesprint.core.domain.user.User
+import com.imagesprint.core.domain.user.UserRepository
+import com.imagesprint.infrastructure.common.DatabaseCleaner
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import kotlin.test.Test
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(locations = ["classpath:application-test.yml"])
+class UserIntegrationTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var databaseCleaner: DatabaseCleaner
+
+    @Autowired
+    lateinit var userRepository: UserRepository
+
+    @BeforeEach
+    fun setup() {
+        databaseCleaner.truncate()
+    }
+
+    @WithMockAuthenticatedUser(userId = 1, provider = "KAKAO")
+    @Test
+    fun `유저 정보 조회 시, 유저 정보를 반환한다`() {
+        // given
+        userRepository.save(
+            User(
+                email = "test@example.com",
+                provider = SocialProvider.KAKAO,
+                nickname = "test",
+            ),
+        )
+
+        // when & then
+        mockMvc
+            .perform(
+                get("/api/v1/users/me")
+                    .contentType(MediaType.APPLICATION_JSON),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.userId").isNotEmpty)
+            .andExpect(jsonPath("$.data.email").value("test@example.com"))
+            .andExpect(jsonPath("$.data.nickname").value("test"))
+    }
+
+    @WithMockAuthenticatedUser(userId = 1, provider = "KAKAO")
+    @Test
+    fun `유저 정보 조회 시, 유저 정보가 없다면 예외를 반환한다`() {
+        // given
+        // 유저 저장 생략 -> DB에 존재하지 않음
+
+        // when & then
+        mockMvc
+            .perform(
+                get("/api/v1/users/me")
+                    .contentType(MediaType.APPLICATION_JSON),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("유저를 찾을 수 없습니다."))
+            .andExpect(jsonPath("$.data").doesNotExist())
+    }
+}

--- a/api-server/src/test/kotlin/com/imagesprint/apiserver/support/SocialAuthMockConfig.kt
+++ b/api-server/src/test/kotlin/com/imagesprint/apiserver/support/SocialAuthMockConfig.kt
@@ -1,30 +1,29 @@
 package com.imagesprint.apiserver.support
 
 import com.imagesprint.core.domain.user.SocialProvider
-import com.imagesprint.core.port.out.user.SocialAuthPort
-import com.imagesprint.core.port.out.user.SocialAuthPortResolver
-import com.imagesprint.core.port.out.user.SocialUserInfo
+import com.imagesprint.core.port.output.user.SocialAuthPort
+import com.imagesprint.core.port.output.user.SocialAuthPortResolver
+import com.imagesprint.core.port.output.user.SocialUserInfo
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
 
 @TestConfiguration
 class SocialAuthMockConfig {
-
     @Bean
     @Primary
-    fun socialAuthPortResolver(): SocialAuthPortResolver {
-        return object : SocialAuthPortResolver {
-            override fun resolve(provider: SocialProvider): SocialAuthPort {
-                return object : SocialAuthPort {
-                    override fun getUserInfo(authCode: String, state: String?): SocialUserInfo {
-                        return SocialUserInfo(
+    fun socialAuthPortResolver(): SocialAuthPortResolver =
+        object : SocialAuthPortResolver {
+            override fun resolve(provider: SocialProvider): SocialAuthPort =
+                object : SocialAuthPort {
+                    override fun getUserInfo(
+                        authCode: String,
+                        state: String?,
+                    ): SocialUserInfo =
+                        SocialUserInfo(
                             email = "mock@test.com",
-                            nickname = "mockUser"
+                            nickname = "mockUser",
                         )
-                    }
                 }
-            }
         }
-    }
 }

--- a/api-server/src/test/kotlin/com/imagesprint/apiserver/support/WithMockAuthenticatedUser.kt
+++ b/api-server/src/test/kotlin/com/imagesprint/apiserver/support/WithMockAuthenticatedUser.kt
@@ -1,0 +1,25 @@
+package com.imagesprint.apiserver.support
+
+import com.imagesprint.apiserver.security.AuthenticatedUser
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.test.context.support.WithSecurityContext
+import org.springframework.security.test.context.support.WithSecurityContextFactory
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@WithSecurityContext(factory = WithMockAuthenticatedUserSecurityContextFactory::class)
+annotation class WithMockAuthenticatedUser(
+    val userId: Long = 1L,
+    val provider: String = "KAKAO",
+)
+
+class WithMockAuthenticatedUserSecurityContextFactory : WithSecurityContextFactory<WithMockAuthenticatedUser> {
+    override fun createSecurityContext(annotation: WithMockAuthenticatedUser): SecurityContext {
+        val context = SecurityContextHolder.createEmptyContext()
+        val principal = AuthenticatedUser(annotation.userId, annotation.provider)
+        context.authentication = UsernamePasswordAuthenticationToken(principal, null, listOf())
+        return context
+    }
+}

--- a/core/src/main/kotlin/com/imagesprint/core/domain/user/User.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/domain/user/User.kt
@@ -1,9 +1,12 @@
 package com.imagesprint.core.domain.user
 
+import java.time.LocalDateTime
+
 data class User(
     val userId: Long? = null,
     val email: String,
     val provider: SocialProvider,
     val nickname: String,
-    val isDeleted: Boolean = false
+    val isDeleted: Boolean = false,
+    val createdAt: LocalDateTime? = null,
 )

--- a/core/src/main/kotlin/com/imagesprint/core/domain/user/UserRepository.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/domain/user/UserRepository.kt
@@ -1,6 +1,12 @@
 package com.imagesprint.core.domain.user
 
 interface UserRepository {
-    fun findBySocialIdentity(email: String, provider: SocialProvider): User?
+    fun findBySocialIdentity(
+        email: String,
+        provider: SocialProvider,
+    ): User?
+
+    fun getUser(userId: Long): User?
+
     fun save(user: User): User
 }

--- a/core/src/main/kotlin/com/imagesprint/core/exception/ErrorCode.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/exception/ErrorCode.kt
@@ -2,9 +2,9 @@ package com.imagesprint.core.exception
 
 enum class ErrorCode(
     val code: String,
-    val message: String
+    val message: String,
 ) {
-    USER_NOT_FOUND("USER_404", "사용자를 찾을 수 없습니다."),
+    USER_NOT_FOUND("USER_404", "유저를 찾을 수 없습니다."),
     INVALID_TOKEN("AUTH_401", "유효하지 않은 토큰입니다."),
-    INTERNAL_SERVER_ERROR("COMMON_500", "서버 오류가 발생했습니다.")
+    INTERNAL_SERVER_ERROR("COMMON_500", "서버 오류가 발생했습니다."),
 }

--- a/core/src/main/kotlin/com/imagesprint/core/port/in/user/SocialLoginUseCase.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/in/user/SocialLoginUseCase.kt
@@ -1,5 +1,0 @@
-package com.imagesprint.core.port.`in`.user
-
-interface SocialLoginUseCase {
-    fun socialAuthenticate(command: SocialAuthCommand): TokenResult
-}

--- a/core/src/main/kotlin/com/imagesprint/core/port/in/user/TokenResult.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/in/user/TokenResult.kt
@@ -1,6 +1,0 @@
-package com.imagesprint.core.port.`in`.user
-
-data class TokenResult(
-    val accessToken: String,
-    val refreshToken: String
-)

--- a/core/src/main/kotlin/com/imagesprint/core/port/input/user/MyProfileResult.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/input/user/MyProfileResult.kt
@@ -1,0 +1,24 @@
+package com.imagesprint.core.port.input.user
+
+import com.imagesprint.core.domain.user.SocialProvider
+import com.imagesprint.core.domain.user.User
+import java.time.LocalDateTime
+
+data class MyProfileResult(
+    val userId: Long,
+    val nickname: String,
+    val email: String,
+    val provider: SocialProvider,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(user: User): MyProfileResult =
+            MyProfileResult(
+                requireNotNull(user.userId) { "유저 ID는 NULL 일 수 없습니다." },
+                user.nickname,
+                user.email,
+                user.provider,
+                user.createdAt ?: LocalDateTime.now(),
+            )
+    }
+}

--- a/core/src/main/kotlin/com/imagesprint/core/port/input/user/SocialAuthCommand.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/input/user/SocialAuthCommand.kt
@@ -1,9 +1,9 @@
-package com.imagesprint.core.port.`in`.user
+package com.imagesprint.core.port.input.user
 
 import com.imagesprint.core.domain.user.SocialProvider
 
 data class SocialAuthCommand(
     val authorizationCode: String,
     val provider: SocialProvider,
-    val state: String?
+    val state: String?,
 )

--- a/core/src/main/kotlin/com/imagesprint/core/port/input/user/SocialLoginUseCase.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/input/user/SocialLoginUseCase.kt
@@ -1,0 +1,5 @@
+package com.imagesprint.core.port.input.user
+
+interface SocialLoginUseCase {
+    fun loginWithSocial(command: SocialAuthCommand): TokenResult
+}

--- a/core/src/main/kotlin/com/imagesprint/core/port/input/user/TokenResult.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/input/user/TokenResult.kt
@@ -1,0 +1,6 @@
+package com.imagesprint.core.port.input.user
+
+data class TokenResult(
+    val accessToken: String,
+    val refreshToken: String,
+)

--- a/core/src/main/kotlin/com/imagesprint/core/port/input/user/UserQueryUseCase.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/input/user/UserQueryUseCase.kt
@@ -1,0 +1,5 @@
+package com.imagesprint.core.port.input.user
+
+interface UserQueryUseCase {
+    fun getMyProfile(userId: Long): MyProfileResult
+}

--- a/core/src/main/kotlin/com/imagesprint/core/port/out/token/RefreshTokenStore.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/out/token/RefreshTokenStore.kt
@@ -1,5 +1,0 @@
-package com.imagesprint.core.port.out.token
-
-interface RefreshTokenStore {
-    fun save(userId: Long, refreshToken: String)
-}

--- a/core/src/main/kotlin/com/imagesprint/core/port/out/token/TokenProvider.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/out/token/TokenProvider.kt
@@ -1,9 +1,0 @@
-package com.imagesprint.core.port.out.token
-
-interface TokenProvider {
-    fun generateAccessToken(userId: Long, provider: String): String
-    fun generateRefreshToken(userId: Long, provider: String): String
-    fun isValidToken(token: String): Boolean
-    fun getUserIdFromToken(token: String): Long
-    fun getProviderFromToken(token: String): String
-}

--- a/core/src/main/kotlin/com/imagesprint/core/port/out/user/SocialAuthPort.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/out/user/SocialAuthPort.kt
@@ -1,5 +1,0 @@
-package com.imagesprint.core.port.out.user
-
-interface SocialAuthPort {
-    fun getUserInfo(authCode: String, state: String?): SocialUserInfo
-}

--- a/core/src/main/kotlin/com/imagesprint/core/port/out/user/SocialUserInfo.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/out/user/SocialUserInfo.kt
@@ -1,6 +1,0 @@
-package com.imagesprint.core.port.out.user
-
-data class SocialUserInfo(
-    val email: String,
-    val nickname: String
-)

--- a/core/src/main/kotlin/com/imagesprint/core/port/output/token/RefreshTokenStore.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/output/token/RefreshTokenStore.kt
@@ -1,0 +1,8 @@
+package com.imagesprint.core.port.output.token
+
+interface RefreshTokenStore {
+    fun save(
+        userId: Long,
+        refreshToken: String,
+    )
+}

--- a/core/src/main/kotlin/com/imagesprint/core/port/output/token/TokenProvider.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/output/token/TokenProvider.kt
@@ -1,0 +1,19 @@
+package com.imagesprint.core.port.output.token
+
+interface TokenProvider {
+    fun generateAccessToken(
+        userId: Long,
+        provider: String,
+    ): String
+
+    fun generateRefreshToken(
+        userId: Long,
+        provider: String,
+    ): String
+
+    fun isValidToken(token: String): Boolean
+
+    fun getUserIdFromToken(token: String): Long
+
+    fun getProviderFromToken(token: String): String
+}

--- a/core/src/main/kotlin/com/imagesprint/core/port/output/user/SocialAuthPort.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/output/user/SocialAuthPort.kt
@@ -1,0 +1,8 @@
+package com.imagesprint.core.port.output.user
+
+interface SocialAuthPort {
+    fun getUserInfo(
+        authCode: String,
+        state: String?,
+    ): SocialUserInfo
+}

--- a/core/src/main/kotlin/com/imagesprint/core/port/output/user/SocialAuthPortResolver.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/output/user/SocialAuthPortResolver.kt
@@ -1,4 +1,4 @@
-package com.imagesprint.core.port.out.user
+package com.imagesprint.core.port.output.user
 
 import com.imagesprint.core.domain.user.SocialProvider
 

--- a/core/src/main/kotlin/com/imagesprint/core/port/output/user/SocialUserInfo.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/output/user/SocialUserInfo.kt
@@ -1,0 +1,6 @@
+package com.imagesprint.core.port.output.user
+
+data class SocialUserInfo(
+    val email: String,
+    val nickname: String,
+)

--- a/core/src/main/kotlin/com/imagesprint/core/service/user/SocialLoginService.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/service/user/SocialLoginService.kt
@@ -2,12 +2,12 @@ package com.imagesprint.core.service.user
 
 import com.imagesprint.core.domain.user.User
 import com.imagesprint.core.domain.user.UserRepository
-import com.imagesprint.core.port.`in`.user.SocialAuthCommand
-import com.imagesprint.core.port.`in`.user.SocialLoginUseCase
-import com.imagesprint.core.port.`in`.user.TokenResult
-import com.imagesprint.core.port.out.token.RefreshTokenStore
-import com.imagesprint.core.port.out.token.TokenProvider
-import com.imagesprint.core.port.out.user.SocialAuthPortResolver
+import com.imagesprint.core.port.input.user.SocialAuthCommand
+import com.imagesprint.core.port.input.user.SocialLoginUseCase
+import com.imagesprint.core.port.input.user.TokenResult
+import com.imagesprint.core.port.output.token.RefreshTokenStore
+import com.imagesprint.core.port.output.token.TokenProvider
+import com.imagesprint.core.port.output.user.SocialAuthPortResolver
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -16,21 +16,21 @@ class SocialLoginService(
     private val userRepository: UserRepository,
     private val socialAuthPortResolver: SocialAuthPortResolver,
     private val tokenProvider: TokenProvider,
-    private val refreshTokenStore: RefreshTokenStore
+    private val refreshTokenStore: RefreshTokenStore,
 ) : SocialLoginUseCase {
-
     @Transactional
-    override fun socialAuthenticate(command: SocialAuthCommand): TokenResult {
+    override fun loginWithSocial(command: SocialAuthCommand): TokenResult {
         val provider = socialAuthPortResolver.resolve(command.provider)
         val socialUserInfo = provider.getUserInfo(command.authorizationCode, command.state)
-        val userInfo = userRepository.findBySocialIdentity(socialUserInfo.email, command.provider)
-            ?: userRepository.save(
-                User(
-                    email = socialUserInfo.email,
-                    provider = command.provider,
-                    nickname = socialUserInfo.nickname
+        val userInfo =
+            userRepository.findBySocialIdentity(socialUserInfo.email, command.provider)
+                ?: userRepository.save(
+                    User(
+                        email = socialUserInfo.email,
+                        provider = command.provider,
+                        nickname = socialUserInfo.nickname,
+                    ),
                 )
-            )
 
         val accessToken = tokenProvider.generateAccessToken(userInfo.userId!!, userInfo.provider.name)
         val refreshToken = tokenProvider.generateRefreshToken(userInfo.userId, userInfo.provider.name)

--- a/core/src/main/kotlin/com/imagesprint/core/service/user/UserQueryService.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/service/user/UserQueryService.kt
@@ -1,0 +1,19 @@
+package com.imagesprint.core.service.user
+
+import com.imagesprint.core.domain.user.UserRepository
+import com.imagesprint.core.exception.CustomException
+import com.imagesprint.core.exception.ErrorCode
+import com.imagesprint.core.port.input.user.MyProfileResult
+import com.imagesprint.core.port.input.user.UserQueryUseCase
+import org.springframework.stereotype.Service
+
+@Service
+class UserQueryService(
+    private val userRepository: UserRepository,
+) : UserQueryUseCase {
+    override fun getMyProfile(userId: Long): MyProfileResult {
+        val user = userRepository.getUser(userId) ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+
+        return MyProfileResult.from(user)
+    }
+}

--- a/core/src/test/kotlin/com/imagesprint/core/service/user/UserQueryServiceTest.kt
+++ b/core/src/test/kotlin/com/imagesprint/core/service/user/UserQueryServiceTest.kt
@@ -1,0 +1,54 @@
+package com.imagesprint.core.service.user
+
+import com.imagesprint.core.domain.user.UserRepository
+import com.imagesprint.core.exception.CustomException
+import com.imagesprint.core.exception.ErrorCode
+import com.imagesprint.core.support.factory.UserTestFactory
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class UserQueryServiceTest {
+    private lateinit var userRepository: UserRepository
+    private lateinit var userQueryService: UserQueryService
+
+    @BeforeEach
+    fun setUp() {
+        userRepository = mockk()
+        userQueryService =
+            UserQueryService(
+                userRepository,
+            )
+    }
+
+    @Test
+    fun `유저 정보를 조회한다`() {
+        // given
+        val userId = 1L
+        val returnUser = UserTestFactory.create(userId)
+        every { userRepository.getUser(userId) } returns returnUser
+
+        // when
+        val result = userRepository.getUser(userId)
+
+        // then
+        assertThat(result?.userId).isEqualTo(userId)
+    }
+
+    @Test
+    fun `유저 정보가 없으면 예외를 반환한다`() {
+        // given
+        val userId = 999L
+        every { userRepository.getUser(any()) } throws CustomException(ErrorCode.USER_NOT_FOUND)
+
+        // when & then
+        assertThatThrownBy {
+            userRepository.getUser(userId) // 이 부분이 예외 발생
+        }.isInstanceOf(CustomException::class.java)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.USER_NOT_FOUND)
+    }
+}

--- a/core/src/test/kotlin/com/imagesprint/core/support/factory/UserTestFactory.kt
+++ b/core/src/test/kotlin/com/imagesprint/core/support/factory/UserTestFactory.kt
@@ -1,4 +1,4 @@
-package com.core.src.test.kotlin.com.imagesprint.core.support.factory
+package com.imagesprint.core.support.factory
 
 import com.imagesprint.core.domain.user.SocialProvider
 import com.imagesprint.core.domain.user.User
@@ -8,13 +8,12 @@ object UserTestFactory {
         id: Long? = null,
         email: String = "test@example.com",
         provider: SocialProvider = SocialProvider.KAKAO,
-        nickname: String = "테스트"
-    ): User {
-        return User(
+        nickname: String = "테스트",
+    ): User =
+        User(
             userId = id,
             email = email,
             provider = provider,
-            nickname = nickname
+            nickname = nickname,
         )
-    }
 }

--- a/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/common/DatabaseCleaner.kt
+++ b/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/common/DatabaseCleaner.kt
@@ -7,7 +7,6 @@ import org.springframework.transaction.annotation.Transactional
 
 @Component
 class DatabaseCleaner {
-
     @PersistenceContext
     private lateinit var entityManager: EntityManager
 
@@ -16,18 +15,14 @@ class DatabaseCleaner {
         entityManager.flush()
         entityManager.clear()
 
-        // 외래 키 무시
-        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate()
-
-        // 테이블 목록 조회 (MySQL 기준)
-        val tableNames = entityManager.createNativeQuery(
-            "SELECT table_name FROM information_schema.tables WHERE table_schema = DATABASE()"
-        ).resultList
+        val tableNames =
+            entityManager
+                .createNativeQuery(
+                    "SELECT table_name FROM information_schema.tables WHERE table_schema = 'PUBLIC'",
+                ).resultList as List<String>
 
         tableNames.forEach { tableName ->
-            entityManager.createNativeQuery("TRUNCATE TABLE `$tableName`").executeUpdate()
+            entityManager.createNativeQuery("DELETE FROM \"$tableName\"").executeUpdate()
         }
-
-        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate()
     }
 }

--- a/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/security/JwtTokenProvider.kt
+++ b/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/security/JwtTokenProvider.kt
@@ -1,6 +1,8 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
 package com.imagesprint.infrastructure.security
 
-import com.imagesprint.core.port.out.token.TokenProvider
+import com.imagesprint.core.port.output.token.TokenProvider
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
 import org.springframework.beans.factory.annotation.Value
@@ -15,11 +17,15 @@ class JwtTokenProvider(
 ) : TokenProvider {
     private val key = Keys.hmacShaKeyFor(secret.toByteArray())
 
-    override fun generateAccessToken(userId: Long, provider: String): String {
+    override fun generateAccessToken(
+        userId: Long,
+        provider: String,
+    ): String {
         val now = Date()
         val expiry = Date(now.time + accessTokenExpiry)
 
-        return Jwts.builder()
+        return Jwts
+            .builder()
             .setSubject(userId.toString())
             .claim("provider", provider)
             .setIssuedAt(now)
@@ -28,11 +34,15 @@ class JwtTokenProvider(
             .compact()
     }
 
-    override fun generateRefreshToken(userId: Long, provider: String): String {
+    override fun generateRefreshToken(
+        userId: Long,
+        provider: String,
+    ): String {
         val now = Date()
         val expiry = Date(now.time + refreshTokenExpiry)
 
-        return Jwts.builder()
+        return Jwts
+            .builder()
             .setSubject(userId.toString())
             .claim("provider", provider)
             .setIssuedAt(now)
@@ -41,20 +51,37 @@ class JwtTokenProvider(
             .compact()
     }
 
-    override fun isValidToken(token: String): Boolean = try {
-        Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token)
-        true
-    } catch (e: Exception) {
-        false
-    }
+    override fun isValidToken(token: String): Boolean =
+        try {
+            Jwts
+                .parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+            true
+        } catch (e: Exception) {
+            false
+        }
 
     override fun getUserIdFromToken(token: String): Long {
-        val claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).body
+        val claims =
+            Jwts
+                .parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .body
         return claims.subject.toLong()
     }
 
     override fun getProviderFromToken(token: String): String {
-        val claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).body
+        val claims =
+            Jwts
+                .parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .body
         return claims["provider"].toString()
     }
 }

--- a/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/token/persistence/RefreshTokenStoreImpl.kt
+++ b/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/token/persistence/RefreshTokenStoreImpl.kt
@@ -1,13 +1,16 @@
 package com.imagesprint.infrastructure.token.persistence
 
-import com.imagesprint.core.port.out.token.RefreshTokenStore
+import com.imagesprint.core.port.output.token.RefreshTokenStore
 import org.springframework.stereotype.Repository
 
 @Repository
 class RefreshTokenStoreImpl(
-    private val repository: TokenJpaRepository
+    private val repository: TokenJpaRepository,
 ) : RefreshTokenStore {
-    override fun save(userId: Long, refreshToken: String) {
+    override fun save(
+        userId: Long,
+        refreshToken: String,
+    ) {
         repository.save(TokenEntity(userId = userId, refreshToken = refreshToken))
     }
 }

--- a/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/user/persistence/UserEntity.kt
+++ b/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/user/persistence/UserEntity.kt
@@ -6,28 +6,24 @@ import com.imagesprint.infrastructure.common.BaseTimeEntity
 import jakarta.persistence.*
 
 @Entity
-@Table(name = "user")
+@Table(name = "`user`")
 class UserEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val userId: Long? = null,
-
     val email: String,
-
     @Enumerated(EnumType.STRING)
     val provider: SocialProvider,
-
     val nickname: String,
-
     val isDeleted: Boolean = false,
 ) : BaseTimeEntity() {
-
-    fun toDomain(): User = User(
-        userId = userId,
-        email = email,
-        provider = provider,
-        nickname = nickname
-    )
+    fun toDomain(): User =
+        User(
+            userId = userId,
+            email = email,
+            provider = provider,
+            nickname = nickname,
+        )
 
     companion object {
         fun fromDomain(user: User): UserEntity =
@@ -35,7 +31,7 @@ class UserEntity(
                 userId = user.userId,
                 email = user.email,
                 provider = user.provider,
-                nickname = user.nickname
+                nickname = user.nickname,
             )
     }
 }

--- a/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/user/persistence/UserJpaRepository.kt
+++ b/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/user/persistence/UserJpaRepository.kt
@@ -4,5 +4,10 @@ import com.imagesprint.core.domain.user.SocialProvider
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserJpaRepository : JpaRepository<UserEntity, Long> {
-    fun findByEmailAndProvider(email: String, provider: SocialProvider): UserEntity?
+    fun findByEmailAndProvider(
+        email: String,
+        provider: SocialProvider,
+    ): UserEntity?
+
+    fun findByUserId(userId: Long): UserEntity?
 }

--- a/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/user/persistence/UserRepositoryImpl.kt
+++ b/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/user/persistence/UserRepositoryImpl.kt
@@ -7,14 +7,14 @@ import org.springframework.stereotype.Repository
 
 @Repository
 class UserRepositoryImpl(
-    private val userJpaRepository: UserJpaRepository
+    private val userJpaRepository: UserJpaRepository,
 ) : UserRepository {
+    override fun findBySocialIdentity(
+        email: String,
+        provider: SocialProvider,
+    ): User? = userJpaRepository.findByEmailAndProvider(email, provider)?.toDomain()
 
-    override fun findBySocialIdentity(email: String, provider: SocialProvider): User? {
-        return userJpaRepository.findByEmailAndProvider(email, provider)?.toDomain()
-    }
+    override fun getUser(userId: Long): User? = userJpaRepository.findByUserId(userId)?.toDomain()
 
-    override fun save(user: User): User {
-        return userJpaRepository.save(UserEntity.fromDomain(user)).toDomain()
-    }
+    override fun save(user: User): User = userJpaRepository.save(UserEntity.fromDomain(user)).toDomain()
 }

--- a/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/user/strategy/KakaoAuthAdapter.kt
+++ b/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/user/strategy/KakaoAuthAdapter.kt
@@ -1,8 +1,8 @@
 package com.imagesprint.infrastructure.user.strategy
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.imagesprint.core.port.out.user.SocialAuthPort
-import com.imagesprint.core.port.out.user.SocialUserInfo
+import com.imagesprint.core.port.output.user.SocialAuthPort
+import com.imagesprint.core.port.output.user.SocialUserInfo
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -14,29 +14,34 @@ import org.springframework.web.reactive.function.client.WebClient
 class KakaoAuthAdapter(
     private val webClient: WebClient,
     @Value("\${oauth.kakao.client-id}") private val clientId: String,
-    @Value("\${oauth.kakao.redirect-uri}") private val redirectUri: String
+    @Value("\${oauth.kakao.redirect-uri}") private val redirectUri: String,
 ) : SocialAuthPort {
     private val log: Logger = LoggerFactory.getLogger(KakaoAuthAdapter::class.java)
 
-    override fun getUserInfo(authCode: String, state: String?): SocialUserInfo {
+    override fun getUserInfo(
+        authCode: String,
+        state: String?,
+    ): SocialUserInfo {
         val token = fetchAccessToken(authCode)
         return fetchUserInfo(token)
     }
 
     private fun fetchAccessToken(code: String): String {
         try {
-            val tokenResponse = webClient.post()
-                .uri("https://kauth.kakao.com/oauth/token")
-                .header("Content-Type", "application/x-www-form-urlencoded")
-                .body(
-                    BodyInserters.fromFormData("grant_type", "authorization_code")
-                        .with("client_id", clientId)
-                        .with("redirect_uri", redirectUri)
-                        .with("code", code)
-                )
-                .retrieve()
-                .bodyToMono(KakaoTokenResponse::class.java)
-                .block() ?: throw RuntimeException("카카오 토큰 응답이 null입니다")
+            val tokenResponse =
+                webClient
+                    .post()
+                    .uri("https://kauth.kakao.com/oauth/token")
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .body(
+                        BodyInserters
+                            .fromFormData("grant_type", "authorization_code")
+                            .with("client_id", clientId)
+                            .with("redirect_uri", redirectUri)
+                            .with("code", code),
+                    ).retrieve()
+                    .bodyToMono(KakaoTokenResponse::class.java)
+                    .block() ?: throw RuntimeException("카카오 토큰 응답이 null입니다")
 
             return tokenResponse.accessToken
         } catch (e: Exception) {
@@ -45,45 +50,45 @@ class KakaoAuthAdapter(
         }
     }
 
-    private fun fetchUserInfo(accessToken: String): SocialUserInfo {
-        return try {
-            val response = webClient.get()
-                .uri("https://kapi.kakao.com/v2/user/me")
-                .header("Authorization", "Bearer $accessToken")
-                .retrieve()
-                .bodyToMono(KakaoUserResponse::class.java)
-                .block() ?: throw RuntimeException("카카오 사용자 정보 응답이 null입니다.")
+    private fun fetchUserInfo(accessToken: String): SocialUserInfo =
+        try {
+            val response =
+                webClient
+                    .get()
+                    .uri("https://kapi.kakao.com/v2/user/me")
+                    .header("Authorization", "Bearer $accessToken")
+                    .retrieve()
+                    .bodyToMono(KakaoUserResponse::class.java)
+                    .block() ?: throw RuntimeException("카카오 유저 정보 응답이 null입니다.")
 
             SocialUserInfo(
                 response.kakaoAccount.email ?: throw RuntimeException("카카오 계정에 이메일이 없습니다."),
-                response.kakaoAccount.profile?.nickname ?: ""
+                response.kakaoAccount.profile?.nickname ?: "",
             )
         } catch (e: Exception) {
-            log.error("카카오 사용자 정보 조회 실패: {}", e.message)
-            throw RuntimeException("카카오 사용자 정보 조회 중 오류가 발생했습니다.", e)
+            log.error("카카오 유저 정보 조회 실패: {}", e.message)
+            throw RuntimeException("카카오 유저 정보 조회 중 오류가 발생했습니다.", e)
         }
-    }
 
     data class KakaoTokenResponse(
         @JsonProperty("access_token")
-        val accessToken: String
+        val accessToken: String,
     )
 
     data class KakaoUserResponse(
         @JsonProperty("kakao_account")
-        val kakaoAccount: KakaoAccount
+        val kakaoAccount: KakaoAccount,
     ) {
         data class KakaoAccount(
             @JsonProperty("email")
             val email: String?,
-
             @JsonProperty("profile")
-            val profile: Profile?
+            val profile: Profile?,
         )
 
         data class Profile(
             @JsonProperty("nickname")
-            val nickname: String?
+            val nickname: String?,
         )
     }
 }

--- a/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/user/strategy/NaverAuthAdapter.kt
+++ b/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/user/strategy/NaverAuthAdapter.kt
@@ -1,8 +1,8 @@
 package com.imagesprint.infrastructure.user.strategy
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.imagesprint.core.port.out.user.SocialAuthPort
-import com.imagesprint.core.port.out.user.SocialUserInfo
+import com.imagesprint.core.port.output.user.SocialAuthPort
+import com.imagesprint.core.port.output.user.SocialUserInfo
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -15,64 +15,77 @@ class NaverAuthAdapter(
     private val webClient: WebClient,
     @Value("\${oauth.naver.client-id}") private val clientId: String,
     @Value("\${oauth.naver.client-secret}") private val clientSecret: String,
-    @Value("\${oauth.naver.redirect-uri}") private val redirectUri: String
+    @Value("\${oauth.naver.redirect-uri}") private val redirectUri: String,
 ) : SocialAuthPort {
     private val log: Logger = LoggerFactory.getLogger(NaverAuthAdapter::class.java)
 
-    override fun getUserInfo(authCode: String, state: String?): SocialUserInfo {
+    override fun getUserInfo(
+        authCode: String,
+        state: String?,
+    ): SocialUserInfo {
         val token = fetchAccessToken(authCode, state)
         return fetchUserInfo(token)
     }
 
-    private fun fetchAccessToken(code: String, state: String?): String {
-        return try {
-            val tokenResponse = webClient.post()
-                .uri("https://nid.naver.com/oauth2.0/token")
-                .header("Content-Type", "application/x-www-form-urlencoded")
-                .body(
-                    BodyInserters.fromFormData("grant_type", "authorization_code")
-                        .with("client_id", clientId)
-                        .with("client_secret", clientSecret)
-                        .with("redirect_uri", redirectUri)
-                        .with("code", code)
-                        .with("state", state ?: "")
-                )
-                .retrieve()
-                .bodyToMono(NaverTokenResponse::class.java)
-                .block() ?: throw RuntimeException("네이버 토큰 응답이 null입니다.")
+    private fun fetchAccessToken(
+        code: String,
+        state: String?,
+    ): String =
+        try {
+            val tokenResponse =
+                webClient
+                    .post()
+                    .uri("https://nid.naver.com/oauth2.0/token")
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .body(
+                        BodyInserters
+                            .fromFormData("grant_type", "authorization_code")
+                            .with("client_id", clientId)
+                            .with("client_secret", clientSecret)
+                            .with("redirect_uri", redirectUri)
+                            .with("code", code)
+                            .with("state", state ?: ""),
+                    ).retrieve()
+                    .bodyToMono(NaverTokenResponse::class.java)
+                    .block() ?: throw RuntimeException("네이버 토큰 응답이 null입니다.")
 
             tokenResponse.accessToken
         } catch (e: Exception) {
             log.error("네이버 AccessToken 요청 실패: {}", e.message)
             throw RuntimeException("네이버 토큰 발급 실패", e)
         }
-    }
 
-    private fun fetchUserInfo(accessToken: String): SocialUserInfo {
-        return try {
-            val response = webClient.get()
-                .uri("https://openapi.naver.com/v1/nid/me")
-                .header("Authorization", "Bearer $accessToken")
-                .retrieve()
-                .bodyToMono(NaverUserResponse::class.java)
-                .block() ?: throw RuntimeException("네이버 사용자 정보 응답이 null입니다.")
+    private fun fetchUserInfo(accessToken: String): SocialUserInfo =
+        try {
+            val response =
+                webClient
+                    .get()
+                    .uri("https://openapi.naver.com/v1/nid/me")
+                    .header("Authorization", "Bearer $accessToken")
+                    .retrieve()
+                    .bodyToMono(NaverUserResponse::class.java)
+                    .block() ?: throw RuntimeException("네이버 유저 정보 응답이 null입니다.")
 
             SocialUserInfo(
                 response.response.email ?: throw RuntimeException("이메일을 찾을 수 없습니다."),
-                response.response.nickname ?: ""
+                response.response.nickname ?: "",
             )
         } catch (e: Exception) {
-            log.error("네이버 사용자 정보 조회 실패: {}", e.message)
-            throw RuntimeException("네이버 사용자 정보 조회 중 오류가 발생했습니다.", e)
+            log.error("네이버 유저 정보 조회 실패: {}", e.message)
+            throw RuntimeException("네이버 유저 정보 조회 중 오류가 발생했습니다.", e)
         }
-    }
 
     data class NaverTokenResponse(
         @JsonProperty("access_token")
-        val accessToken: String
+        val accessToken: String,
     )
 
-    data class NaverUserResponse(val response: Response) {
-        data class Response(val email: String?, val nickname: String?)
+    data class NaverUserResponse(
+        val response: Response,
+    ) {
+        data class Response(
+            val email: String?,
+            val nickname: String?,
+        )
     }
 }

--- a/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/user/strategy/SocialAuthAdapterResolver.kt
+++ b/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/user/strategy/SocialAuthAdapterResolver.kt
@@ -1,8 +1,8 @@
 package com.imagesprint.infrastructure.user.strategy
 
 import com.imagesprint.core.domain.user.SocialProvider
-import com.imagesprint.core.port.out.user.SocialAuthPort
-import com.imagesprint.core.port.out.user.SocialAuthPortResolver
+import com.imagesprint.core.port.output.user.SocialAuthPort
+import com.imagesprint.core.port.output.user.SocialAuthPortResolver
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 
@@ -11,11 +11,9 @@ class SocialAuthAdapterResolver(
     @Qualifier("KAKAO") private val kakaoAdapter: SocialAuthPort,
     @Qualifier("NAVER") private val naverAdapter: SocialAuthPort,
 ) : SocialAuthPortResolver {
-
-    override fun resolve(provider: SocialProvider): SocialAuthPort {
-        return when (provider) {
+    override fun resolve(provider: SocialProvider): SocialAuthPort =
+        when (provider) {
             SocialProvider.KAKAO -> kakaoAdapter
             SocialProvider.NAVER -> naverAdapter
         }
-    }
 }


### PR DESCRIPTION
## 요약

<!-- 관련된 칸반 티켓정보를 포함해 주세요. -->
Closes #3
## 변경 사항

- **사용자 인증 처리**
    - [x]  HTTP 요청의 Authorization 헤더에서 JWT 추출
    - [x]  JWT 검증 후 사용자 식별 (userId 획득)
    - [x]  존재하지 않는 사용자거나 비활성 유저일 경우 401 Unauthorized 반환
- **Request Body 파싱 및 유효성 검증**
    - [x]  user 테이블에서 user_id 기준으로 사용자 정보 조회
- **결과를 JSON으로 반환한다.**
<!-- 이 Pull Request에서 구체적으로 어떤 변경이 이루어졌는지 설명해 주세요.  
문제를 해결하기 위해 어떤 접근 방식을 택했는지, 구현상의 특징이 있다면 함께 기술해 주세요. -->

## 체크리스트

- [x] 이해하기 어려운 코드에는 주석을 추가했습니다  
- [x] 관련 문서를 수정했습니다  
- [x] 새로운 경고가 발생하지 않습니다  
- [x] 수정한 기능 또는 추가한 기능에 대해 테스트를 작성했습니다  
- [x] 의존성 있는 변경 사항이 병합 및 배포되었습니다

## 관련 이슈
-  #3 
<!-- 이 PR이 해결하는 관련 이슈나 버그가 있다면 연결해 주세요. 어떤 문제를 해결하는 코드인지 맥락을 제공합니다. -->

## 리뷰 반영 사항

<!-- PR리뷰 반형 사항 -->

<details>
<summary><strong>선택 항목 펼치기</strong></summary>

## 스크린샷

<!-- 시각적인 변경 사항이 있다면 스크린샷이나 GIF를 포함해 주세요. 리뷰어가 쉽게 이해할 수 있습니다. -->

## 테스트 방법

<!-- PR에서 수행한 변경 사항을 어떻게 테스트할 수 있는지 설명해 주세요. 리뷰어가 직접 확인할 수 있도록 돕습니다. -->

## 리뷰어 참고사항

<!-- 리뷰어에게 특별히 알려야 할 사항이나 고려할 점이 있다면 여기에 작성해 주세요. -->

</details>