### PR TITLE
feat: 알림 목록 조회 api 구현

### DIFF
--- a/api-server/src/main/kotlin/com/imagesprint/apiserver/controller/notification/NotificationController.kt
+++ b/api-server/src/main/kotlin/com/imagesprint/apiserver/controller/notification/NotificationController.kt
@@ -1,0 +1,32 @@
+package com.imagesprint.apiserver.controller.notification
+
+import com.imagesprint.apiserver.controller.common.ApiResultResponse
+import com.imagesprint.apiserver.controller.common.ApiResultResponse.Companion.ok
+import com.imagesprint.apiserver.controller.common.ApiVersions
+import com.imagesprint.apiserver.controller.user.dto.NotificationPageResponse
+import com.imagesprint.apiserver.security.AuthenticatedUser
+import com.imagesprint.core.port.input.notification.GetNotificationPageQuery
+import com.imagesprint.core.port.input.notification.NotificationQueryUseCase
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("${ApiVersions.V1}/notifications")
+class NotificationController(
+    private val notificationQueryUseCase: NotificationQueryUseCase,
+) {
+    @GetMapping
+    fun getMyNotifications(
+        @AuthenticationPrincipal user: AuthenticatedUser,
+        @RequestParam cursor: Long?,
+        @RequestParam(defaultValue = "10") pageSize: Int,
+    ): ApiResultResponse<NotificationPageResponse> {
+        val query = GetNotificationPageQuery(user.userId, cursor, pageSize)
+        val result = notificationQueryUseCase.getNotifications(query)
+
+        return ok(NotificationPageResponse.from(result))
+    }
+}

--- a/api-server/src/main/kotlin/com/imagesprint/apiserver/controller/user/dto/NotificationPageResponse.kt
+++ b/api-server/src/main/kotlin/com/imagesprint/apiserver/controller/user/dto/NotificationPageResponse.kt
@@ -1,0 +1,18 @@
+package com.imagesprint.apiserver.controller.user.dto
+
+import com.imagesprint.core.port.input.notification.NotificationPage
+
+data class NotificationPageResponse(
+    val notifications: List<NotificationResponse>,
+    val nextCursor: Long?,
+    val hasNext: Boolean,
+) {
+    companion object {
+        fun from(page: NotificationPage): NotificationPageResponse =
+            NotificationPageResponse(
+                notifications = page.notifications.map { NotificationResponse.from(it) },
+                nextCursor = page.nextCursor,
+                hasNext = page.hasNext,
+            )
+    }
+}

--- a/api-server/src/main/kotlin/com/imagesprint/apiserver/controller/user/dto/NotificationResponse.kt
+++ b/api-server/src/main/kotlin/com/imagesprint/apiserver/controller/user/dto/NotificationResponse.kt
@@ -1,0 +1,22 @@
+package com.imagesprint.apiserver.controller.user.dto
+
+import com.imagesprint.core.domain.notification.Notification
+import com.imagesprint.core.domain.notification.NotificationType
+import java.time.LocalDateTime
+
+data class NotificationResponse(
+    val id: Long,
+    val content: String,
+    val type: NotificationType,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(notification: Notification): NotificationResponse =
+            NotificationResponse(
+                id = notification.notificationId!!,
+                content = notification.content,
+                type = notification.type,
+                createdAt = notification.createdAt!!,
+            )
+    }
+}

--- a/api-server/src/test/kotlin/com/imagesprint/apiserver/controller/AuthControllerTest.kt
+++ b/api-server/src/test/kotlin/com/imagesprint/apiserver/controller/AuthControllerTest.kt
@@ -1,6 +1,7 @@
-package com.imagesprint.apiserver.controller.auth
+package com.imagesprint.apiserver.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.imagesprint.apiserver.controller.auth.AuthController
 import com.imagesprint.apiserver.controller.auth.dto.SocialLoginRequest
 import com.imagesprint.apiserver.security.AuthenticatedUser
 import com.imagesprint.core.domain.user.SocialProvider

--- a/api-server/src/test/kotlin/com/imagesprint/apiserver/controller/NotificationControllerTest.kt
+++ b/api-server/src/test/kotlin/com/imagesprint/apiserver/controller/NotificationControllerTest.kt
@@ -1,0 +1,196 @@
+package com.imagesprint.apiserver.controller
+
+import com.imagesprint.apiserver.controller.notification.NotificationController
+import com.imagesprint.apiserver.security.AuthenticatedUser
+import com.imagesprint.core.domain.notification.Notification
+import com.imagesprint.core.domain.notification.NotificationType
+import com.imagesprint.core.port.input.notification.GetNotificationPageQuery
+import com.imagesprint.core.port.input.notification.NotificationPage
+import com.imagesprint.core.port.input.notification.NotificationQueryUseCase
+import com.imagesprint.core.port.output.token.TokenProvider
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import java.time.LocalDateTime
+import kotlin.test.Test
+
+@WebMvcTest(NotificationController::class)
+@AutoConfigureMockMvc(addFilters = false)
+class NotificationControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockkBean
+    private lateinit var notificationQueryUseCase: NotificationQueryUseCase
+
+    @MockkBean
+    private lateinit var tokenProvider: TokenProvider
+
+    @AfterEach
+    fun tearDown() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `컨트롤러 - 커서 없이 요청하면 첫 페이지를 조회한다`() {
+        // given
+        val userId = 1L
+        val pageSize = 3
+        val authenticatedUser = AuthenticatedUser(userId = userId, provider = "KAKAO")
+        val notifications =
+            listOf(
+                Notification(
+                    notificationId = 3L,
+                    userId = 1L,
+                    content = "알림1",
+                    type = NotificationType.JOB_DONE,
+                    createdAt = LocalDateTime.now(),
+                ),
+                Notification(
+                    notificationId = 2L,
+                    userId = 1L,
+                    content = "알림2",
+                    type = NotificationType.JOB_DONE,
+                    createdAt = LocalDateTime.now(),
+                ),
+                Notification(
+                    notificationId = 1L,
+                    userId = 1L,
+                    content = "알림3",
+                    type = NotificationType.JOB_DONE,
+                    createdAt = LocalDateTime.now(),
+                ),
+            )
+        val page =
+            NotificationPage(
+                notifications = notifications,
+                nextCursor = 1L,
+                hasNext = true,
+            )
+
+        every {
+            notificationQueryUseCase.getNotifications(GetNotificationPageQuery(userId, null, pageSize))
+        } returns page
+
+        val token = UsernamePasswordAuthenticationToken(authenticatedUser, null)
+        SecurityContextHolder.getContext().authentication = token
+
+        // when & then
+        mockMvc
+            .get("/api/v1/notifications") {
+                param("pageSize", "$pageSize")
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.data.notifications.size()") { value(3) }
+                jsonPath("$.data.nextCursor") { value(1L) }
+                jsonPath("$.data.hasNext") { value(true) }
+            }
+
+        verify(exactly = 1) {
+            notificationQueryUseCase.getNotifications(GetNotificationPageQuery(userId, null, pageSize))
+        }
+    }
+
+    @Test
+    fun `컨트롤러 - 알림 목록을 커서 기반으로 조회하면 200 OK와 결과를 반환한다`() {
+        // given
+        val authenticatedUser = AuthenticatedUser(userId = 1L, provider = "KAKAO")
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken(authenticatedUser, null)
+
+        val notification1 =
+            Notification(
+                notificationId = 100L,
+                userId = 1L,
+                content = "알림1",
+                type = NotificationType.JOB_DONE,
+                createdAt = LocalDateTime.now(),
+            )
+
+        val notification2 =
+            Notification(
+                notificationId = 99L,
+                userId = 1L,
+                content = "알림2",
+                type = NotificationType.JOB_DONE,
+                createdAt = LocalDateTime.now(),
+            )
+
+        val pageResult =
+            NotificationPage(
+                notifications = listOf(notification1, notification2),
+                nextCursor = 99L,
+                hasNext = true,
+            )
+
+        every {
+            notificationQueryUseCase.getNotifications(
+                GetNotificationPageQuery(userId = 1L, cursor = null, pageSize = 2),
+            )
+        } returns pageResult
+
+        // when & then
+        mockMvc
+            .get("/api/v1/notifications") {
+                contentType = MediaType.APPLICATION_JSON
+                param("pageSize", "2")
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.data.notifications.size()") { value(2) }
+                jsonPath("$.data.notifications[0].content") { value("알림1") }
+                jsonPath("$.data.hasNext") { value(true) }
+                jsonPath("$.data.nextCursor") { value(99) }
+            }
+
+        verify(exactly = 1) {
+            notificationQueryUseCase.getNotifications(
+                GetNotificationPageQuery(userId = 1L, cursor = null, pageSize = 2),
+            )
+        }
+    }
+
+    @Test
+    fun `컨트롤러 - 알림이 없으면 빈 목록과 null 커서를 반환한다`() {
+        // given
+        val userId = 1L
+        val pageSize = 10
+        val authenticatedUser = AuthenticatedUser(userId = userId, provider = "KAKAO")
+        val page =
+            NotificationPage(
+                notifications = emptyList(),
+                nextCursor = null,
+                hasNext = false,
+            )
+
+        every {
+            notificationQueryUseCase.getNotifications(GetNotificationPageQuery(userId, null, pageSize))
+        } returns page
+
+        val token = UsernamePasswordAuthenticationToken(authenticatedUser, null)
+        SecurityContextHolder.getContext().authentication = token
+
+        // when & then
+        mockMvc
+            .get("/api/v1/notifications") {
+                param("pageSize", "$pageSize")
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.data.notifications.size()") { value(0) }
+                jsonPath("$.data.nextCursor") { doesNotExist() }
+                jsonPath("$.data.hasNext") { value(false) }
+            }
+
+        verify(exactly = 1) {
+            notificationQueryUseCase.getNotifications(GetNotificationPageQuery(userId, null, pageSize))
+        }
+    }
+}

--- a/api-server/src/test/kotlin/com/imagesprint/apiserver/controller/UserControllerTest.kt
+++ b/api-server/src/test/kotlin/com/imagesprint/apiserver/controller/UserControllerTest.kt
@@ -1,5 +1,6 @@
-package com.imagesprint.apiserver.controller.user
+package com.imagesprint.apiserver.controller
 
+import com.imagesprint.apiserver.controller.user.UserController
 import com.imagesprint.apiserver.support.WithMockAuthenticatedUser
 import com.imagesprint.core.domain.user.SocialProvider
 import com.imagesprint.core.port.input.user.MyProfileResult

--- a/api-server/src/test/kotlin/com/imagesprint/apiserver/controller/WebhookControllerTest.kt
+++ b/api-server/src/test/kotlin/com/imagesprint/apiserver/controller/WebhookControllerTest.kt
@@ -1,6 +1,7 @@
-package com.imagesprint.apiserver.controller.webhook
+package com.imagesprint.apiserver.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.imagesprint.apiserver.controller.webhook.WebhookController
 import com.imagesprint.apiserver.controller.webhook.dto.RegisterWebhookRequest
 import com.imagesprint.apiserver.controller.webhook.dto.TestWebhookUrlRequest
 import com.imagesprint.apiserver.security.AuthenticatedUser

--- a/api-server/src/test/kotlin/com/imagesprint/apiserver/integration/AuthIntegrationTest.kt
+++ b/api-server/src/test/kotlin/com/imagesprint/apiserver/integration/AuthIntegrationTest.kt
@@ -1,4 +1,4 @@
-package com.imagesprint.apiserver.controller.auth
+package com.imagesprint.apiserver.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.imagesprint.apiserver.controller.auth.dto.SocialLoginRequest

--- a/api-server/src/test/kotlin/com/imagesprint/apiserver/integration/NotificationIntegrationTest.kt
+++ b/api-server/src/test/kotlin/com/imagesprint/apiserver/integration/NotificationIntegrationTest.kt
@@ -1,0 +1,100 @@
+package com.imagesprint.apiserver.integration
+
+import com.imagesprint.apiserver.support.WithMockAuthenticatedUser
+import com.imagesprint.core.domain.notification.Notification
+import com.imagesprint.core.domain.notification.NotificationType
+import com.imagesprint.core.port.output.notfication.NotificationRepository
+import com.imagesprint.infrastructure.common.DatabaseCleaner
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import kotlin.test.Test
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(locations = ["classpath:application-test.yml"])
+@ActiveProfiles("test")
+class NotificationIntegrationTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var databaseCleaner: DatabaseCleaner
+
+    @Autowired
+    private lateinit var notificationRepository: NotificationRepository
+
+    @BeforeEach
+    fun setup() {
+        databaseCleaner.truncate()
+
+        val notifications =
+            listOf(
+                Notification(userId = 1L, content = "알림1", type = NotificationType.JOB_DONE),
+                Notification(userId = 1L, content = "알림2", type = NotificationType.JOB_FAILED),
+                Notification(userId = 1L, content = "알림3", type = NotificationType.ZIP_EXPIRED),
+            )
+        notificationRepository.saveAll(notifications)
+    }
+
+    @Test
+    @WithMockAuthenticatedUser(userId = 1, provider = "KAKAO")
+    fun `통합 - 알림 목록 조회 시 최근 순으로 페이징된 결과가 반환된다`() {
+        // when & then
+        mockMvc
+            .get("/api/v1/notifications") {
+                param("pageSize", "2")
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.data.notifications.size()") { value(2) }
+                jsonPath("$.data.notifications[0].content") { value("알림3") }
+                jsonPath("$.data.notifications[1].content") { value("알림2") }
+                jsonPath("$.data.hasNext") { value(true) }
+                jsonPath("$.data.nextCursor") { isNumber() }
+            }
+    }
+
+    @Test
+    @WithMockAuthenticatedUser(userId = 1, provider = "KAKAO")
+    fun `통합 - 알림이 없으면 빈 목록이 반환된다`() {
+        // given
+        databaseCleaner.truncate()
+
+        // when & then
+        mockMvc
+            .get("/api/v1/notifications") {
+                param("pageSize", "10")
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.data.notifications") { isArray() }
+                jsonPath("$.data.notifications.size()") { value(0) }
+                jsonPath("$.data.hasNext") { value(false) }
+                jsonPath("$.data.nextCursor") { isEmpty() }
+            }
+    }
+
+    @Test
+    @WithMockAuthenticatedUser(userId = 1, provider = "KAKAO")
+    fun `통합 - 커서를 기준으로 다음 알림 페이지를 조회한다`() {
+        // given
+        val cursor = 2L
+
+        // when & then
+        mockMvc
+            .get("/api/v1/notifications") {
+                param("cursor", cursor.toString())
+                param("pageSize", "10")
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.data.notifications.size()") { value(1) }
+                jsonPath("$.data.notifications[0].content") { value("알림1") } // createdAt 기준 desc
+                jsonPath("$.data.hasNext") { value(false) }
+                jsonPath("$.data.nextCursor") { isEmpty() }
+            }
+    }
+}

--- a/api-server/src/test/kotlin/com/imagesprint/apiserver/integration/UserIntegrationTest.kt
+++ b/api-server/src/test/kotlin/com/imagesprint/apiserver/integration/UserIntegrationTest.kt
@@ -1,4 +1,4 @@
-package com.imagesprint.apiserver.controller.user
+package com.imagesprint.apiserver.integration
 
 import com.imagesprint.apiserver.support.WithMockAuthenticatedUser
 import com.imagesprint.core.domain.user.SocialProvider

--- a/api-server/src/test/kotlin/com/imagesprint/apiserver/integration/WebhookIntegrationTest.kt
+++ b/api-server/src/test/kotlin/com/imagesprint/apiserver/integration/WebhookIntegrationTest.kt
@@ -1,4 +1,4 @@
-package com.imagesprint.apiserver.controller.webhook
+package com.imagesprint.apiserver.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.imagesprint.apiserver.controller.webhook.dto.RegisterWebhookRequest

--- a/core/src/main/kotlin/com/imagesprint/core/domain/notification/Notification.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/domain/notification/Notification.kt
@@ -1,0 +1,11 @@
+package com.imagesprint.core.domain.notification
+
+import java.time.LocalDateTime
+
+class Notification(
+    val notificationId: Long? = null,
+    val userId: Long,
+    val content: String,
+    val type: NotificationType,
+    val createdAt: LocalDateTime? = null,
+)

--- a/core/src/main/kotlin/com/imagesprint/core/domain/notification/NotificationType.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/domain/notification/NotificationType.kt
@@ -1,0 +1,8 @@
+package com.imagesprint.core.domain.notification
+
+enum class NotificationType {
+    JOB_STARTED,
+    JOB_DONE,
+    JOB_FAILED,
+    ZIP_EXPIRED,
+}

--- a/core/src/main/kotlin/com/imagesprint/core/port/input/notification/GetNotificationPageQuery.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/input/notification/GetNotificationPageQuery.kt
@@ -1,0 +1,7 @@
+package com.imagesprint.core.port.input.notification
+
+data class GetNotificationPageQuery(
+    val userId: Long,
+    val cursor: Long?,
+    val pageSize: Int,
+)

--- a/core/src/main/kotlin/com/imagesprint/core/port/input/notification/NotificationPage.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/input/notification/NotificationPage.kt
@@ -1,0 +1,9 @@
+package com.imagesprint.core.port.input.notification
+
+import com.imagesprint.core.domain.notification.Notification
+
+data class NotificationPage(
+    val notifications: List<Notification>,
+    val nextCursor: Long?,
+    val hasNext: Boolean,
+)

--- a/core/src/main/kotlin/com/imagesprint/core/port/input/notification/NotificationQueryUseCase.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/input/notification/NotificationQueryUseCase.kt
@@ -1,0 +1,5 @@
+package com.imagesprint.core.port.input.notification
+
+interface NotificationQueryUseCase {
+    fun getNotifications(query: GetNotificationPageQuery): NotificationPage
+}

--- a/core/src/main/kotlin/com/imagesprint/core/port/output/notfication/NotificationRepository.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/output/notfication/NotificationRepository.kt
@@ -1,0 +1,14 @@
+package com.imagesprint.core.port.output.notfication
+
+import com.imagesprint.core.domain.notification.Notification
+import com.imagesprint.core.port.input.notification.NotificationPage
+
+interface NotificationRepository {
+    fun getNotificationsByCursor(
+        userId: Long,
+        cursor: Long?,
+        pageSize: Int,
+    ): NotificationPage
+
+    fun saveAll(notifications: List<Notification>)
+}

--- a/core/src/main/kotlin/com/imagesprint/core/service/notification/NotificationQueryService.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/service/notification/NotificationQueryService.kt
@@ -1,0 +1,19 @@
+package com.imagesprint.core.service.notification
+
+import com.imagesprint.core.port.input.notification.GetNotificationPageQuery
+import com.imagesprint.core.port.input.notification.NotificationPage
+import com.imagesprint.core.port.input.notification.NotificationQueryUseCase
+import com.imagesprint.core.port.output.notfication.NotificationRepository
+import org.springframework.stereotype.Service
+
+@Service
+class NotificationQueryService(
+    private val notificationRepository: NotificationRepository,
+) : NotificationQueryUseCase {
+    override fun getNotifications(query: GetNotificationPageQuery): NotificationPage =
+        notificationRepository.getNotificationsByCursor(
+            userId = query.userId,
+            cursor = query.cursor,
+            pageSize = query.pageSize,
+        )
+}

--- a/core/src/test/kotlin/com/imagesprint/core/service/notification/NotificationQueryServiceTest.kt
+++ b/core/src/test/kotlin/com/imagesprint/core/service/notification/NotificationQueryServiceTest.kt
@@ -1,0 +1,91 @@
+package com.imagesprint.core.service.notification
+
+import com.imagesprint.core.domain.notification.NotificationType
+import com.imagesprint.core.port.input.notification.GetNotificationPageQuery
+import com.imagesprint.core.port.input.notification.NotificationPage
+import com.imagesprint.core.port.output.notfication.NotificationRepository
+import com.imagesprint.core.support.factory.NotificationTestFactory
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import java.time.LocalDateTime
+import kotlin.test.Test
+
+class NotificationQueryServiceTest {
+    private lateinit var notificationRepository: NotificationRepository
+    private lateinit var notificationQueryService: NotificationQueryService
+
+    @BeforeEach
+    fun setup() {
+        notificationRepository = mockk()
+        notificationQueryService = NotificationQueryService(notificationRepository)
+    }
+
+    @Test
+    fun `단위 - 알림 목록을 정상적으로 조회한다`() {
+        // given
+        val query =
+            GetNotificationPageQuery(
+                userId = 1L,
+                cursor = null,
+                pageSize = 3,
+            )
+
+        val now = LocalDateTime.now()
+        val notifications =
+            listOf(
+                NotificationTestFactory.create(
+                    id = 101L,
+                    userId = 1L,
+                    content = "알림1",
+                    type = NotificationType.JOB_FAILED,
+                    createdAt = now,
+                ),
+                NotificationTestFactory.create(
+                    id = 100L,
+                    userId = 1L,
+                    content = "알림2",
+                    type = NotificationType.JOB_DONE,
+                    createdAt = now.minusSeconds(1),
+                ),
+                NotificationTestFactory.create(
+                    id = 99L,
+                    userId = 1L,
+                    content = "알림3",
+                    type = NotificationType.JOB_DONE,
+                    createdAt = now.minusSeconds(2),
+                ),
+            )
+
+        val expected =
+            NotificationPage(
+                notifications = notifications,
+                nextCursor = 99L,
+                hasNext = true,
+            )
+
+        every {
+            notificationRepository.getNotificationsByCursor(
+                userId = 1L,
+                cursor = null,
+                pageSize = 3,
+            )
+        } returns expected
+
+        // when
+        val result = notificationQueryService.getNotifications(query)
+
+        // then
+        assertThat(result).isEqualTo(expected)
+        assertThat(result.notifications).hasSize(3)
+        verify(exactly = 1) {
+            notificationRepository.getNotificationsByCursor(
+                userId = 1L,
+                cursor = null,
+                pageSize = 3,
+            )
+        }
+    }
+}

--- a/core/src/test/kotlin/com/imagesprint/core/support/factory/NotificationTestFactory.kt
+++ b/core/src/test/kotlin/com/imagesprint/core/support/factory/NotificationTestFactory.kt
@@ -1,0 +1,22 @@
+package com.imagesprint.core.support.factory
+
+import com.imagesprint.core.domain.notification.Notification
+import com.imagesprint.core.domain.notification.NotificationType
+import java.time.LocalDateTime
+
+object NotificationTestFactory {
+    fun create(
+        id: Long? = null,
+        userId: Long = 1L,
+        content: String = "테스트 알림",
+        type: NotificationType = NotificationType.JOB_DONE,
+        createdAt: LocalDateTime = LocalDateTime.now(),
+    ): Notification =
+        Notification(
+            notificationId = id,
+            userId = userId,
+            content = content,
+            type = type,
+            createdAt = createdAt,
+        )
+}

--- a/infrastructure-jpa/build.gradle.kts
+++ b/infrastructure-jpa/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     kotlin("plugin.spring") version "1.9.25"
     // JPA 어노테이션에 자동으로 protected no-arg constructor가 생성
     kotlin("plugin.jpa") version "1.9.25"
+    kotlin("kapt")
     id("org.springframework.boot") version "3.5.3" apply false
     id("io.spring.dependency-management") version "1.1.7"
 }
@@ -45,11 +46,19 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0")
 //    implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
 
+    // QueryDSL core
+    implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta") // 반드시 `:jakarta` 붙여야 함 (JPA 3 기준)
+    kapt("com.querydsl:querydsl-apt:5.0.0:jakarta") // QueryDSL Q 클래스 생성용
+
     // DB 드라이버 예시
-    runtimeOnly ("com.h2database:h2")
+    runtimeOnly("com.h2database:h2")
     runtimeOnly("com.mysql:mysql-connector-j")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+}
+
+kapt {
+    correctErrorTypes = true
 }
 
 tasks.withType<Test> {

--- a/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/config/QuerydslConfig.kt
+++ b/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/config/QuerydslConfig.kt
@@ -1,0 +1,14 @@
+package com.imagesprint.infrastructure.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QuerydslConfig(
+    private val entityManager: EntityManager,
+) {
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory = JPAQueryFactory(entityManager)
+}

--- a/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/notification/persistence/NotificationEntity.kt
+++ b/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/notification/persistence/NotificationEntity.kt
@@ -1,0 +1,49 @@
+package com.imagesprint.infrastructure.notification.persistence
+
+import com.imagesprint.core.domain.notification.Notification
+import com.imagesprint.core.domain.notification.NotificationType
+import com.imagesprint.infrastructure.common.BaseTimeEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "notification")
+class NotificationEntity(
+    userId: Long,
+    content: String,
+    type: NotificationType,
+) : BaseTimeEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val notificationId: Long? = null
+
+    @Column(nullable = false)
+    var userId: Long = userId
+        protected set
+
+    @Column(nullable = false)
+    var content: String = content
+        protected set
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var type: NotificationType = type
+        protected set
+
+    fun toDomain(): Notification =
+        Notification(
+            notificationId = notificationId,
+            userId = userId,
+            content = content,
+            type = type,
+            createdAt = createdAt,
+        )
+
+    companion object {
+        fun from(notification: Notification): NotificationEntity =
+            NotificationEntity(
+                userId = notification.userId,
+                content = notification.content,
+                type = notification.type,
+            )
+    }
+}

--- a/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/notification/persistence/NotificationJpaRepository.kt
+++ b/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/notification/persistence/NotificationJpaRepository.kt
@@ -1,0 +1,7 @@
+package com.imagesprint.infrastructure.notification.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface NotificationJpaRepository :
+    JpaRepository<NotificationEntity, Long>,
+    NotificationQueryRepositoryCustom

--- a/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/notification/persistence/NotificationQueryRepositoryCustom.kt
+++ b/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/notification/persistence/NotificationQueryRepositoryCustom.kt
@@ -1,0 +1,9 @@
+package com.imagesprint.infrastructure.notification.persistence
+
+interface NotificationQueryRepositoryCustom {
+    fun findByUserIdWithCursor(
+        userId: Long,
+        cursor: Long?,
+        limit: Int,
+    ): List<NotificationEntity>
+}

--- a/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/notification/persistence/NotificationQueryRepositoryCustomImpl.kt
+++ b/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/notification/persistence/NotificationQueryRepositoryCustomImpl.kt
@@ -1,0 +1,24 @@
+package com.imagesprint.infrastructure.notification.persistence
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+
+class NotificationQueryRepositoryCustomImpl(
+    private val queryFactory: JPAQueryFactory,
+) : NotificationQueryRepositoryCustom {
+    override fun findByUserIdWithCursor(
+        userId: Long,
+        cursor: Long?,
+        limit: Int,
+    ): List<NotificationEntity> {
+        val notification = QNotificationEntity.notificationEntity
+
+        return queryFactory
+            .selectFrom(notification)
+            .where(
+                notification.userId.eq(userId),
+                cursor?.let { notification.notificationId.lt(it) }, // 커서 조건
+            ).orderBy(notification.notificationId.desc())
+            .limit((limit + 1).toLong()) // hasNext 판단 위해 +1
+            .fetch()
+    }
+}

--- a/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/notification/persistence/NotificationRepositoryImpl.kt
+++ b/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/notification/persistence/NotificationRepositoryImpl.kt
@@ -1,0 +1,33 @@
+package com.imagesprint.infrastructure.notification.persistence
+
+import com.imagesprint.core.domain.notification.Notification
+import com.imagesprint.core.port.input.notification.NotificationPage
+import com.imagesprint.core.port.output.notfication.NotificationRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class NotificationRepositoryImpl(
+    private val notificationJpaRepository: NotificationJpaRepository,
+) : NotificationRepository {
+    override fun getNotificationsByCursor(
+        userId: Long,
+        cursor: Long?,
+        pageSize: Int,
+    ): NotificationPage {
+        val results = notificationJpaRepository.findByUserIdWithCursor(userId, cursor, pageSize)
+
+        val hasNext = results.size > pageSize
+        val pageItems = if (hasNext) results.dropLast(1) else results
+        val nextCursor = if (hasNext) pageItems.lastOrNull()?.notificationId else null
+
+        return NotificationPage(
+            notifications = pageItems.map { it.toDomain() },
+            nextCursor = nextCursor,
+            hasNext = hasNext,
+        )
+    }
+
+    override fun saveAll(notifications: List<Notification>) {
+        notificationJpaRepository.saveAll(notifications.map(NotificationEntity::from))
+    }
+}

--- a/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/token/persistence/TokenEntity.kt
+++ b/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/token/persistence/TokenEntity.kt
@@ -6,13 +6,22 @@ import jakarta.persistence.*
 
 @Entity
 @Table(name = "token")
-data class TokenEntity(
+class TokenEntity(
+    userId: Long,
+    refreshToken: String,
+) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val tokenId: Long? = null,
-    val userId: Long,
-    val refreshToken: String,
-) : BaseTimeEntity() {
+    val tokenId: Long? = null
+
+    @Column(nullable = false)
+    var userId: Long = userId
+        protected set
+
+    @Column(nullable = false)
+    var refreshToken: String = refreshToken
+        protected set
+
     fun toDomain(): Token =
         Token(
             tokenId = tokenId,
@@ -21,9 +30,8 @@ data class TokenEntity(
         )
 
     companion object {
-        fun fromDomain(token: Token): TokenEntity =
+        fun from(token: Token): TokenEntity =
             TokenEntity(
-                tokenId = token.tokenId,
                 userId = token.userId,
                 refreshToken = token.refreshToken,
             )

--- a/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/token/persistence/TokenRepositoryImpl.kt
+++ b/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/token/persistence/TokenRepositoryImpl.kt
@@ -11,6 +11,6 @@ class TokenRepositoryImpl(
     override fun getRefreshToken(userId: Long): Token? = repository.getByUserId(userId)?.toDomain()
 
     override fun save(token: Token) {
-        repository.save(TokenEntity.fromDomain(token))
+        repository.save(TokenEntity.from(token))
     }
 }

--- a/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/user/persistence/UserEntity.kt
+++ b/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/user/persistence/UserEntity.kt
@@ -8,15 +8,32 @@ import jakarta.persistence.*
 @Entity
 @Table(name = "`user`")
 class UserEntity(
+    email: String,
+    provider: SocialProvider,
+    nickname: String,
+    isDeleted: Boolean = false,
+) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val userId: Long? = null,
-    val email: String,
+    val userId: Long? = null
+
+    @Column(nullable = false)
+    var email: String = email
+        protected set
+
     @Enumerated(EnumType.STRING)
-    val provider: SocialProvider,
-    val nickname: String,
-    val isDeleted: Boolean = false,
-) : BaseTimeEntity() {
+    @Column(nullable = false)
+    var provider: SocialProvider = provider
+        protected set
+
+    @Column(nullable = false)
+    var nickname: String = nickname
+        protected set
+
+    @Column
+    var isDeleted: Boolean = isDeleted
+        protected set
+
     fun toDomain(): User =
         User(
             userId = userId,
@@ -26,12 +43,12 @@ class UserEntity(
         )
 
     companion object {
-        fun fromDomain(user: User): UserEntity =
+        fun from(user: User): UserEntity =
             UserEntity(
-                userId = user.userId,
                 email = user.email,
                 provider = user.provider,
                 nickname = user.nickname,
+                isDeleted = false,
             )
     }
 }

--- a/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/user/persistence/UserRepositoryImpl.kt
+++ b/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/user/persistence/UserRepositoryImpl.kt
@@ -16,5 +16,5 @@ class UserRepositoryImpl(
 
     override fun getUser(userId: Long): User? = userJpaRepository.findByUserId(userId)?.toDomain()
 
-    override fun save(user: User): User = userJpaRepository.save(UserEntity.fromDomain(user)).toDomain()
+    override fun save(user: User): User = userJpaRepository.save(UserEntity.from(user)).toDomain()
 }

--- a/infrastructure-r2dbc/src/main/resources/application.properties
+++ b/infrastructure-r2dbc/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=infrastructure


### PR DESCRIPTION
## 요약

<!-- 관련된 칸반 티켓정보를 포함해 주세요. -->
Closes #9 
## 변경 사항

<!-- 이 Pull Request에서 구체적으로 어떤 변경이 이루어졌는지 설명해 주세요.  
문제를 해결하기 위해 어떤 접근 방식을 택했는지, 구현상의 특징이 있다면 함께 기술해 주세요. -->
- **API 호출 처리**
    - [ ]  요청 헤더의 Authorization을 통해 사용자 인증 (JWT 검증)
    - [ ]  로그인한 사용자의 userId를 파싱해 가져온다.
- **DB에서 알림 목록 조회**
    - [ ]  notification 테이블에서 해당 사용자(user_id)의 알림을 조회
    - [ ]  최신순 정렬 (ORDER BY created_at DESC)
    - [ ]  기본은 최근 10개, 추가적으로 페이지네이션 (커서 기반)
## 체크리스트

- [ ] 이해하기 어려운 코드에는 주석을 추가했습니다  
- [ ] 관련 문서를 수정했습니다  
- [ ] 새로운 경고가 발생하지 않습니다  
- [ ] 수정한 기능 또는 추가한 기능에 대해 테스트를 작성했습니다  
- [ ] 의존성 있는 변경 사항이 병합 및 배포되었습니다

## 관련 이슈
- #9 
<!-- 이 PR이 해결하는 관련 이슈나 버그가 있다면 연결해 주세요. 어떤 문제를 해결하는 코드인지 맥락을 제공합니다. -->

## 리뷰 반영 사항

<!-- PR리뷰 반형 사항 -->

<details>
<summary><strong>선택 항목 펼치기</strong></summary>

## 스크린샷

<!-- 시각적인 변경 사항이 있다면 스크린샷이나 GIF를 포함해 주세요. 리뷰어가 쉽게 이해할 수 있습니다. -->

## 테스트 방법

<!-- PR에서 수행한 변경 사항을 어떻게 테스트할 수 있는지 설명해 주세요. 리뷰어가 직접 확인할 수 있도록 돕습니다. -->

## 리뷰어 참고사항

<!-- 리뷰어에게 특별히 알려야 할 사항이나 고려할 점이 있다면 여기에 작성해 주세요. -->

</details>