### PR TITLE
feat: 내 작업 목록 조회 api 구현

### DIFF
--- a/api-server/src/main/kotlin/com/imagesprint/apiserver/controller/job/JobController.kt
+++ b/api-server/src/main/kotlin/com/imagesprint/apiserver/controller/job/JobController.kt
@@ -9,21 +9,28 @@ import com.imagesprint.apiserver.security.AuthenticatedUser
 import com.imagesprint.core.exception.CustomException
 import com.imagesprint.core.exception.ErrorCode
 import com.imagesprint.core.port.input.job.CreateJobUseCase
+import com.imagesprint.core.port.input.job.GetMyJobsUseCase
 import com.imagesprint.core.port.input.job.ImageUploadMeta
 import jakarta.validation.Valid
 import org.springframework.http.MediaType
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestPart
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 
 @RestController
 @RequestMapping("${ApiVersions.V1}/jobs")
 class JobController(
     private val createJobUseCase: CreateJobUseCase,
+    private val getMyJobsUseCase: GetMyJobsUseCase,
 ) {
+    @GetMapping
+    fun getJobs(
+        @AuthenticationPrincipal user: AuthenticatedUser,
+    ): ApiResultResponse<List<JobResponse>> {
+        val result = getMyJobsUseCase.getMyJobs(user.userId)
+        return ok(result.map { JobResponse.from(it) })
+    }
+
     @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     fun createJob(
         @AuthenticationPrincipal user: AuthenticatedUser,

--- a/api-server/src/main/kotlin/com/imagesprint/apiserver/controller/job/dto/JobResponse.kt
+++ b/api-server/src/main/kotlin/com/imagesprint/apiserver/controller/job/dto/JobResponse.kt
@@ -1,12 +1,15 @@
 package com.imagesprint.apiserver.controller.job.dto
 
 import com.imagesprint.core.port.input.job.JobResult
+import java.time.LocalDateTime
 
 data class JobResponse(
     val jobId: Long,
     val status: String,
     val imageCount: Int,
     val originalSize: Long,
+    val createdAt: LocalDateTime,
+    val zipUrl: String? = null,
 ) {
     companion object {
         fun from(result: JobResult): JobResponse =
@@ -15,6 +18,8 @@ data class JobResponse(
                 result.status,
                 result.imageCount,
                 result.originalSize,
+                result.createdAt,
+                result.zirUrl,
             )
     }
 }

--- a/core/src/main/kotlin/com/imagesprint/core/port/input/job/GetMyJobsUseCase.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/input/job/GetMyJobsUseCase.kt
@@ -1,0 +1,5 @@
+package com.imagesprint.core.port.input.job
+
+interface GetMyJobsUseCase {
+    fun getMyJobs(userId: Long): List<JobResult>
+}

--- a/core/src/main/kotlin/com/imagesprint/core/port/input/job/JobResult.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/input/job/JobResult.kt
@@ -1,8 +1,12 @@
 package com.imagesprint.core.port.input.job
 
+import java.time.LocalDateTime
+
 data class JobResult(
     val jobId: Long,
     val status: String,
     val imageCount: Int,
     val originalSize: Long,
+    val createdAt: LocalDateTime,
+    val zirUrl: String? = null,
 )

--- a/core/src/main/kotlin/com/imagesprint/core/port/output/job/JobRepository.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/port/output/job/JobRepository.kt
@@ -4,4 +4,6 @@ import com.imagesprint.core.domain.job.Job
 
 interface JobRepository {
     fun saveJob(job: Job): Job
+
+    fun getMyJobs(userId: Long): List<Job>
 }

--- a/core/src/main/kotlin/com/imagesprint/core/service/job/CreateJobService.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/service/job/CreateJobService.kt
@@ -134,6 +134,7 @@ class CreateJobService(
             status = savedJob.status.name,
             imageCount = savedImages.size,
             originalSize = savedImages.sumOf { it.size },
+            createdAt = savedJob.createdAt,
         )
     }
 

--- a/core/src/main/kotlin/com/imagesprint/core/service/job/GetMyJobsService.kt
+++ b/core/src/main/kotlin/com/imagesprint/core/service/job/GetMyJobsService.kt
@@ -1,0 +1,25 @@
+package com.imagesprint.core.service.job
+
+import com.imagesprint.core.port.input.job.GetMyJobsUseCase
+import com.imagesprint.core.port.input.job.JobResult
+import com.imagesprint.core.port.output.job.JobRepository
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
+
+@Profile("api")
+@Service
+class GetMyJobsService(
+    private val jobRepository: JobRepository,
+) : GetMyJobsUseCase {
+    override fun getMyJobs(userId: Long): List<JobResult> =
+        jobRepository.getMyJobs(userId).map { job ->
+            JobResult(
+                jobId = job.jobId!!,
+                status = job.status.name,
+                imageCount = job.imageCount,
+                originalSize = job.originalSize,
+                createdAt = job.createdAt,
+                zirUrl = job.zipUrl,
+            )
+        }
+}

--- a/core/src/test/kotlin/com/imagesprint/core/service/job/CreateJobServiceTest.kt
+++ b/core/src/test/kotlin/com/imagesprint/core/service/job/CreateJobServiceTest.kt
@@ -39,7 +39,7 @@ class CreateJobServiceTest {
     }
 
     @Test
-    fun `정상적으로 이미지 변환 Job을 생성하고 큐에 등록한다`() {
+    fun `단위 - 정상적으로 이미지 변환 Job을 생성하고 큐에 등록한다`() {
         // given
         val command = CreateJobCommandTestFactory.valid()
         val fakeImages = listOf(ImageFileTestFactory.create(), ImageFileTestFactory.create())
@@ -68,7 +68,7 @@ class CreateJobServiceTest {
     }
 
     @Test
-    fun `quality 값이 유효하지 않으면 CustomException이 발생한다`() {
+    fun `단위 - quality 값이 유효하지 않으면 CustomException이 발생한다`() {
         // given
         val invalidCommand = CreateJobCommandTestFactory.withQuality(150)
 
@@ -81,7 +81,7 @@ class CreateJobServiceTest {
     }
 
     @Test
-    fun `파일 저장 중 예외가 발생하면 트랜잭션 롤백과 함께 CustomException이 발생한다`() {
+    fun `단위 - 파일 저장 중 예외가 발생하면 트랜잭션 롤백과 함께 CustomException이 발생한다`() {
         // given
         val command = CreateJobCommandTestFactory.valid()
         val fakeImages = listOf(ImageFileTestFactory.create(), ImageFileTestFactory.create())
@@ -109,7 +109,7 @@ class CreateJobServiceTest {
     }
 
     @Test
-    fun `큐 등록 중 예외가 발생하면 트랜잭션 롤백과 함께 CustomException이 발생한다`() {
+    fun `단위 - 큐 등록 중 예외가 발생하면 트랜잭션 롤백과 함께 CustomException이 발생한다`() {
         // given
         val command = CreateJobCommandTestFactory.valid()
         val fakeImages = listOf(ImageFileTestFactory.create(), ImageFileTestFactory.create())

--- a/core/src/test/kotlin/com/imagesprint/core/service/job/GetMyJobsServiceTest.kt
+++ b/core/src/test/kotlin/com/imagesprint/core/service/job/GetMyJobsServiceTest.kt
@@ -1,0 +1,70 @@
+package com.imagesprint.core.service.job
+
+import com.imagesprint.core.port.output.job.JobRepository
+import com.imagesprint.core.support.factory.JobTestFactory
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import kotlin.test.Test
+
+class GetMyJobsServiceTest {
+    private lateinit var jobRepository: JobRepository
+    private lateinit var getMyJobsService: GetMyJobsService
+
+    @BeforeEach
+    fun setUp() {
+        jobRepository = mockk()
+        getMyJobsService = GetMyJobsService(jobRepository)
+    }
+
+    @Test
+    fun `단위 - 정상적으로 사용자의 Job 목록을 조회한다`() {
+        // given
+        val userId = 1L
+        val jobList =
+            listOf(
+                JobTestFactory.create(jobId = 101L),
+                JobTestFactory.create(jobId = 102L),
+            )
+        every { jobRepository.getMyJobs(userId) } returns jobList
+
+        // when
+        val result = getMyJobsService.getMyJobs(userId)
+
+        // then
+        assertThat(result).hasSize(2)
+        assertThat(result[0].jobId).isEqualTo(101L)
+        assertThat(result[1].jobId).isEqualTo(102L)
+        verify(exactly = 1) { jobRepository.getMyJobs(userId) }
+    }
+
+    @Test
+    fun `단위 - 사용자의 Job이 하나도 없으면 빈 리스트를 반환한다`() {
+        // given
+        val userId = 2L
+        every { jobRepository.getMyJobs(userId) } returns emptyList()
+
+        // when
+        val result = getMyJobsService.getMyJobs(userId)
+
+        // then
+        assertThat(result).isEmpty()
+        verify(exactly = 1) { jobRepository.getMyJobs(userId) }
+    }
+
+    @Test
+    fun `단위 - Job의 ID가 null인 경우는 변환에서 예외가 발생해야 한다`() {
+        // given
+        val userId = 3L
+        val job = JobTestFactory.create(jobId = null)
+        every { jobRepository.getMyJobs(userId) } returns listOf(job)
+
+        // when & then
+        assertThatThrownBy {
+            getMyJobsService.getMyJobs(userId)
+        }.isInstanceOf(NullPointerException::class.java)
+    }
+}

--- a/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/job/persistence/JobJpaRepository.kt
+++ b/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/job/persistence/JobJpaRepository.kt
@@ -2,4 +2,6 @@ package com.imagesprint.infrastructure.job.persistence
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface JobJpaRepository : JpaRepository<JobEntity, Long>
+interface JobJpaRepository : JpaRepository<JobEntity, Long> {
+    fun findAllByUserId(userId: Long): List<JobEntity>
+}

--- a/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/job/persistence/JobRepositoryImpl.kt
+++ b/infrastructure-jpa/src/main/kotlin/com/imagesprint/infrastructure/job/persistence/JobRepositoryImpl.kt
@@ -22,6 +22,12 @@ class JobRepositoryImpl(
         return savedEntity.toDomain()
     }
 
+    override fun getMyJobs(userId: Long): List<Job> =
+        jobJpaRepository
+            .findAllByUserId(userId)
+            .map { it.toDomain() }
+            .sortedByDescending { it.createdAt }
+
     override fun saveImages(images: List<ImageFile>): List<ImageFile> {
         val imageFileEntities = images.map { ImageFileEntity.from(it) }
         val savedEntities = imageFileJpaRepository.saveAll(imageFileEntities)


### PR DESCRIPTION
## 요약

<!-- 관련된 칸반 티켓정보를 포함해 주세요. -->
Closes #15 
## 변경 사항

<!-- 이 Pull Request에서 구체적으로 어떤 변경이 이루어졌는지 설명해 주세요.  
문제를 해결하기 위해 어떤 접근 방식을 택했는지, 구현상의 특징이 있다면 함께 기술해 주세요. -->

- [x]  사용자가 작업 목록 조회 API를 구현한다.
    - [x]  사용자가 작업 요청한 작업 정보를 DB 데이터에서 조회한다.
    - [x]  조회된 작업 정보 리스트를 배열 형태 응답으로 반환한다.
- [x]  녹화 목록 조회에 성공하면 성공 응답 전송.
    - [x]  조회 결과 없으면 빈 배열 응답
    - [x]  **`200 OK`** 성공 응답
- [x]  요청 실패 시:
    - [x]  인증 정보가 없는 요청일 시 `401` 상태 코드와 “인증되지 않은 사용자입니다.” 응답을 반환한다.
    - [x]  내부 서버에 오류가 발생했을 시 `500`상태 코드와 “서버에서 요청을 처리할 수 없습니다 ” 응답을 반환한다.
## 체크리스트

- [x] 이해하기 어려운 코드에는 주석을 추가했습니다  
- [x] 관련 문서를 수정했습니다  
- [x] 새로운 경고가 발생하지 않습니다  
- [x] 수정한 기능 또는 추가한 기능에 대해 테스트를 작성했습니다  
- [x] 의존성 있는 변경 사항이 병합 및 배포되었습니다

## 관련 이슈
- #15 
<!-- 이 PR이 해결하는 관련 이슈나 버그가 있다면 연결해 주세요. 어떤 문제를 해결하는 코드인지 맥락을 제공합니다. -->

## 리뷰 반영 사항

<!-- PR리뷰 반형 사항 -->

<details>
<summary><strong>선택 항목 펼치기</strong></summary>

## 스크린샷

<!-- 시각적인 변경 사항이 있다면 스크린샷이나 GIF를 포함해 주세요. 리뷰어가 쉽게 이해할 수 있습니다. -->

## 테스트 방법

<!-- PR에서 수행한 변경 사항을 어떻게 테스트할 수 있는지 설명해 주세요. 리뷰어가 직접 확인할 수 있도록 돕습니다. -->

## 리뷰어 참고사항

<!-- 리뷰어에게 특별히 알려야 할 사항이나 고려할 점이 있다면 여기에 작성해 주세요. -->

</details>